### PR TITLE
Titanic project is not submitted

### DIFF
--- a/projects/titanic_survival_exploration/project_description.md
+++ b/projects/titanic_survival_exploration/project_description.md
@@ -35,7 +35,12 @@ This project contains three files:
 - `visuals.py`: This Python script provides supplementary visualizations for the project. Do not modify.
 
 In the Terminal or Command Prompt, navigate to the folder containing the project files, and then use the command `jupyter notebook titanic_survival_exploration.ipynb` to open up a browser window or tab to work with your notebook. Alternatively, you can use the command `jupyter notebook` or `ipython notebook` and navigate to the notebook file in the browser window that opens. Follow the instructions in the notebook and answer each question presented to successfully complete the project. A **README** file has also been provided with the project files which may contain additional necessary information or instruction for the project. 
-## Submitting the Project
+
+------
+
+## Submitting the Project (NOT REQUIRED FOR THIS PRACTICE PROJECT)
+
+**Since this is a practice project, you do not have to submit your project.  Read the following notes to get a feel for how project submission and evaluation will work for your other projects.**
 
 ### Evaluation
 Your project will be reviewed by a Udacity reviewer against the **<a href="https://review.udacity.com/#!/rubrics/147/view" target="_blank"> Titanic Survival Exploration project rubric</a>**. Be sure to review this rubric thoroughly and self-evaluate your project before submission. All criteria found in the rubric must be *meeting specifications* for you to pass.


### PR DESCRIPTION
Make it clear that the titanic practice project should not be submitted for evaluation.

I am in the MLND Jan 2018 cohort and spent some time today (incorrectly) trying to follow the project submission notes in `project_description.md`.  This PR is a text change to try to save others the same pain.